### PR TITLE
External SMTP notes

### DIFF
--- a/src/perch/configuration/email.md
+++ b/src/perch/configuration/email.md
@@ -36,4 +36,10 @@ define('PERCH_EMAIL_USERNAME', 'your.name@gmail.com');
 define('PERCH_EMAIL_PASSWORD', 'your gmail password');
 ```
 
-(Note: if sending through Gmail, you now need to enable [less secure apps settings](https://www.google.com/settings/security/lesssecureapps) otherwise you'll receive a Could Not Authenticate message in Perch.)
+## Gmail
+If sending through Gmail, you now need to enable [less secure apps settings](https://www.google.com/settings/security/lesssecureapps) otherwise you'll receive a Could Not Authenticate message in Perch.
+
+## Microsoft Office 365
+If sending through Office 365, the `PERCH_EMAIL_FROM` value must match the value of `PERCH_EMAIL_USERNAME` (your Office 365 email address).
+
+Microsoft may reject sending emails if the `PERCH_EMAIL_FROM_NAME` is set to an email address.


### PR DESCRIPTION
- Added a Gmail heading to the existing note so it is easier to find
- Added notes for sending emails via Office 365